### PR TITLE
Add Category model

### DIFF
--- a/src/main/java/mate/academy/controller/AuthenticationController.java
+++ b/src/main/java/mate/academy/controller/AuthenticationController.java
@@ -1,5 +1,7 @@
 package mate.academy.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mate.academy.dto.user.UserLoginRequestDto;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Authentication management", description = "Endpoints for managing users registration")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/auth")
@@ -22,12 +25,17 @@ public class AuthenticationController {
     private final AuthenticationService authenticationService;
 
     @PostMapping("/registration")
+    @Operation(summary = "Register a new user",
+            description = "Register a new user by providing their details such as username, "
+                    + "password, and email. ")
     public UserResponseDto register(@RequestBody @Valid UserRegistrationRequestDto requestDto)
             throws RegistrationException {
         return userService.register(requestDto);
     }
 
     @PostMapping("/login")
+    @Operation(summary = "Authenticate user",
+            description = "Login an existing user by validating their username and password. ")
     public UserLoginResponseDto login(@RequestBody @Valid UserLoginRequestDto request) {
         return authenticationService.authenticate(request);
     }

--- a/src/main/java/mate/academy/controller/CategoryController.java
+++ b/src/main/java/mate/academy/controller/CategoryController.java
@@ -1,0 +1,81 @@
+package mate.academy.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import mate.academy.dto.book.BookDtoWithoutCategoryIds;
+import mate.academy.dto.category.CategoryDto;
+import mate.academy.service.BookService;
+import mate.academy.service.CategoryService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Category management", description = "Endpoints for managing categories")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/categories")
+public class CategoryController {
+    private final CategoryService categoryService;
+    private final BookService bookService;
+
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping
+    @Operation(summary = "Create a new category", description = "Create a new category")
+    public CategoryDto createCategory(@RequestBody @Valid CategoryDto requestDto) {
+        return categoryService.save(requestDto);
+    }
+
+    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
+    @GetMapping
+    @Operation(summary = "Get all categories", description = "Get all available categories")
+    public List<CategoryDto> getAll(Pageable pageable) {
+        return categoryService.findAll(pageable);
+    }
+
+    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
+    @GetMapping("/{id}")
+    @Operation(summary = "Get category by ID",
+            description = "Retrieve a category by its unique identifier")
+    public CategoryDto getCategoryById(@PathVariable Long id) {
+        return categoryService.getById(id);
+    }
+
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/{id}")
+    @Operation(summary = "Update category by ID",
+            description = "Update the details of an existing category by its unique identifier")
+    public CategoryDto updateCategory(@PathVariable Long id,
+                                      @RequestBody @Valid CategoryDto requestDto) {
+        return categoryService.update(id, requestDto);
+    }
+
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete category by ID",
+            description = "Delete a category by its unique identifier")
+    public void deleteCategory(@PathVariable Long id) {
+        categoryService.deleteById(id);
+    }
+
+    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
+    @GetMapping("/{id}/books")
+    @Operation(summary = "Get books from category by ID",
+            description = "Retrieve all books from category by its unique identifier")
+    public List<BookDtoWithoutCategoryIds> getBooksByCategoryId(@PathVariable Long id,
+                                                                Pageable pageable) {
+        return bookService.getBooksByCategoryId(id, pageable);
+    }
+}

--- a/src/main/java/mate/academy/controller/CategoryController.java
+++ b/src/main/java/mate/academy/controller/CategoryController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import mate.academy.dto.book.BookDtoWithoutCategoryIds;
 import mate.academy.dto.category.CategoryDto;
+import mate.academy.dto.category.CreateCategoryRequestDto;
 import mate.academy.service.BookService;
 import mate.academy.service.CategoryService;
 import org.springframework.data.domain.Pageable;
@@ -33,7 +34,7 @@ public class CategoryController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping
     @Operation(summary = "Create a new category", description = "Create a new category")
-    public CategoryDto createCategory(@RequestBody @Valid CategoryDto requestDto) {
+    public CategoryDto createCategory(@RequestBody @Valid CreateCategoryRequestDto requestDto) {
         return categoryService.save(requestDto);
     }
 
@@ -57,7 +58,7 @@ public class CategoryController {
     @Operation(summary = "Update category by ID",
             description = "Update the details of an existing category by its unique identifier")
     public CategoryDto updateCategory(@PathVariable Long id,
-                                      @RequestBody @Valid CategoryDto requestDto) {
+                                      @RequestBody @Valid CreateCategoryRequestDto requestDto) {
         return categoryService.update(id, requestDto);
     }
 

--- a/src/main/java/mate/academy/dto/book/BookDto.java
+++ b/src/main/java/mate/academy/dto/book/BookDto.java
@@ -1,14 +1,19 @@
 package mate.academy.dto.book;
 
 import java.math.BigDecimal;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 
-public record BookDto(
-        Long id,
-        String title,
-        String author,
-        String isbn,
-        BigDecimal price,
-        String description,
-        String coverImage
-) {
+@Getter
+@Setter
+public class BookDto {
+    private Long id;
+    private String title;
+    private String author;
+    private String isbn;
+    private BigDecimal price;
+    private String description;
+    private String coverImage;
+    private List<Long> categoryIds;
 }

--- a/src/main/java/mate/academy/dto/book/BookDtoWithoutCategoryIds.java
+++ b/src/main/java/mate/academy/dto/book/BookDtoWithoutCategoryIds.java
@@ -1,0 +1,14 @@
+package mate.academy.dto.book;
+
+import java.math.BigDecimal;
+
+public record BookDtoWithoutCategoryIds(
+        Long id,
+        String title,
+        String author,
+        String isbn,
+        BigDecimal price,
+        String description,
+        String coverImage
+) {
+}

--- a/src/main/java/mate/academy/dto/book/CreateBookRequestDto.java
+++ b/src/main/java/mate/academy/dto/book/CreateBookRequestDto.java
@@ -1,24 +1,24 @@
 package mate.academy.dto.book;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
 import java.math.BigDecimal;
 import java.util.List;
 import mate.academy.validation.Isbn;
 
 public record CreateBookRequestDto(
-        @NotBlank
+        @NotEmpty
         String title,
-        @NotBlank
+        @NotEmpty
         String author,
         @Isbn
         String isbn,
-        @NotNull
+        @NotEmpty
         @Min(0)
         BigDecimal price,
         String description,
         String coverImage,
+        @NotEmpty
         List<Long> categoryIds
 ) {
 }

--- a/src/main/java/mate/academy/dto/book/CreateBookRequestDto.java
+++ b/src/main/java/mate/academy/dto/book/CreateBookRequestDto.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import java.util.List;
 import mate.academy.validation.Isbn;
 
 public record CreateBookRequestDto(
@@ -17,6 +18,7 @@ public record CreateBookRequestDto(
         @Min(0)
         BigDecimal price,
         String description,
-        String coverImage
+        String coverImage,
+        List<Long> categoryIds
 ) {
 }

--- a/src/main/java/mate/academy/dto/book/CreateBookRequestDto.java
+++ b/src/main/java/mate/academy/dto/book/CreateBookRequestDto.java
@@ -1,19 +1,21 @@
 package mate.academy.dto.book;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.List;
 import mate.academy.validation.Isbn;
 
 public record CreateBookRequestDto(
-        @NotEmpty
+        @NotBlank
         String title,
-        @NotEmpty
+        @NotBlank
         String author,
         @Isbn
         String isbn,
-        @NotEmpty
+        @NotNull
         @Min(0)
         BigDecimal price,
         String description,

--- a/src/main/java/mate/academy/dto/category/CategoryDto.java
+++ b/src/main/java/mate/academy/dto/category/CategoryDto.java
@@ -1,0 +1,11 @@
+package mate.academy.dto.category;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CategoryDto(
+        Long id,
+        @NotBlank
+        String name,
+        String description
+) {
+}

--- a/src/main/java/mate/academy/dto/category/CategoryDto.java
+++ b/src/main/java/mate/academy/dto/category/CategoryDto.java
@@ -1,10 +1,7 @@
 package mate.academy.dto.category;
 
-import jakarta.validation.constraints.NotBlank;
-
 public record CategoryDto(
         Long id,
-        @NotBlank
         String name,
         String description
 ) {

--- a/src/main/java/mate/academy/dto/category/CreateCategoryRequestDto.java
+++ b/src/main/java/mate/academy/dto/category/CreateCategoryRequestDto.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Size;
 
 public record CreateCategoryRequestDto(
         @NotBlank
-
         @Size(min = 3, max = 100)
         String name,
         @Size(min = 8, max = 1000)

--- a/src/main/java/mate/academy/dto/category/CreateCategoryRequestDto.java
+++ b/src/main/java/mate/academy/dto/category/CreateCategoryRequestDto.java
@@ -1,10 +1,14 @@
 package mate.academy.dto.category;
 
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record CreateCategoryRequestDto(
-        @NotEmpty
+        @NotBlank
+
+        @Size(min = 3, max = 100)
         String name,
+        @Size(min = 8, max = 1000)
         String description
 ) {
 }

--- a/src/main/java/mate/academy/dto/category/CreateCategoryRequestDto.java
+++ b/src/main/java/mate/academy/dto/category/CreateCategoryRequestDto.java
@@ -1,0 +1,10 @@
+package mate.academy.dto.category;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record CreateCategoryRequestDto(
+        @NotEmpty
+        String name,
+        String description
+) {
+}

--- a/src/main/java/mate/academy/dto/user/UserRegistrationRequestDto.java
+++ b/src/main/java/mate/academy/dto/user/UserRegistrationRequestDto.java
@@ -2,9 +2,8 @@ package mate.academy.dto.user;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import mate.academy.validation.FieldMatch;
-import org.hibernate.validator.constraints.Length;
 
 @FieldMatch.List({
         @FieldMatch(
@@ -14,14 +13,14 @@ import org.hibernate.validator.constraints.Length;
         )
 })
 public record UserRegistrationRequestDto(
-        @NotEmpty
+        @NotBlank
         @Email
         String email,
-        @NotEmpty
-        @Length(min = 8, max = 20)
+        @NotBlank
+        @Size(min = 8, max = 20)
         String password,
         @NotBlank
-        @Length(min = 8, max = 20)
+        @Size(min = 8, max = 20)
         String repeatPassword,
         @NotBlank
         String firstName,

--- a/src/main/java/mate/academy/dto/user/UserRegistrationRequestDto.java
+++ b/src/main/java/mate/academy/dto/user/UserRegistrationRequestDto.java
@@ -2,6 +2,7 @@ package mate.academy.dto.user;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import mate.academy.validation.FieldMatch;
 import org.hibernate.validator.constraints.Length;
 
@@ -13,10 +14,10 @@ import org.hibernate.validator.constraints.Length;
         )
 })
 public record UserRegistrationRequestDto(
-        @NotBlank
+        @NotEmpty
         @Email
         String email,
-        @NotBlank
+        @NotEmpty
         @Length(min = 8, max = 20)
         String password,
         @NotBlank

--- a/src/main/java/mate/academy/exception/CustomGlobalExceptionHandler.java
+++ b/src/main/java/mate/academy/exception/CustomGlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package mate.academy.exception;
 
+import io.jsonwebtoken.JwtException;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -18,6 +19,17 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 @ControllerAdvice
 public class CustomGlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(JwtException.class)
+    protected ResponseEntity<Object> handleJwtException(
+            JwtException exception, WebRequest request) {
+        Map<String, Object> body = getBody(
+                exception.getMessage(),
+                request.getDescription(false),
+                HttpStatus.UNAUTHORIZED
+        );
+        return new ResponseEntity<>(body, HttpStatus.UNAUTHORIZED);
+    }
 
     @ExceptionHandler(RegistrationException.class)
     protected ResponseEntity<Object> handleRegistrationException(

--- a/src/main/java/mate/academy/mapper/BookMapper.java
+++ b/src/main/java/mate/academy/mapper/BookMapper.java
@@ -1,17 +1,32 @@
 package mate.academy.mapper;
 
+import java.util.List;
 import mate.academy.config.MapperConfig;
 import mate.academy.dto.book.BookDto;
+import mate.academy.dto.book.BookDtoWithoutCategoryIds;
 import mate.academy.dto.book.CreateBookRequestDto;
 import mate.academy.model.Book;
+import mate.academy.model.Category;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
 
 @Mapper(config = MapperConfig.class)
 public interface BookMapper {
+
     BookDto toDto(Book book);
 
-    Book toModel(CreateBookRequestDto requestDto);
+    Book toEntity(CreateBookRequestDto requestDto);
 
     void updateBookFromDto(CreateBookRequestDto requestDto, @MappingTarget Book book);
+
+    BookDtoWithoutCategoryIds toDtoWithoutCategories(Book book);
+
+    @AfterMapping
+    default void setCategoryIds(@MappingTarget BookDto bookDto, Book book) {
+        List<Long> categoryIds = book.getCategories().stream()
+                .map(Category::getId)
+                .toList();
+        bookDto.setCategoryIds(categoryIds);
+    }
 }

--- a/src/main/java/mate/academy/mapper/CategoryMapper.java
+++ b/src/main/java/mate/academy/mapper/CategoryMapper.java
@@ -2,6 +2,7 @@ package mate.academy.mapper;
 
 import mate.academy.config.MapperConfig;
 import mate.academy.dto.category.CategoryDto;
+import mate.academy.dto.category.CreateCategoryRequestDto;
 import mate.academy.model.Category;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -11,8 +12,11 @@ import org.mapstruct.MappingTarget;
 public interface CategoryMapper {
     CategoryDto toDto(Category category);
 
+    Category toEntity(CreateCategoryRequestDto requestDto);
+
     Category toEntity(CategoryDto categoryDto);
 
     @Mapping(target = "id", ignore = true)
-    void updateCategoryFromDto(CategoryDto categoryDto, @MappingTarget Category category);
+    void updateCategoryFromDto(CreateCategoryRequestDto requestDto,
+                               @MappingTarget Category category);
 }

--- a/src/main/java/mate/academy/mapper/CategoryMapper.java
+++ b/src/main/java/mate/academy/mapper/CategoryMapper.java
@@ -1,0 +1,18 @@
+package mate.academy.mapper;
+
+import mate.academy.config.MapperConfig;
+import mate.academy.dto.category.CategoryDto;
+import mate.academy.model.Category;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(config = MapperConfig.class)
+public interface CategoryMapper {
+    CategoryDto toDto(Category category);
+
+    Category toEntity(CategoryDto categoryDto);
+
+    @Mapping(target = "id", ignore = true)
+    void updateCategoryFromDto(CategoryDto categoryDto, @MappingTarget Category category);
+}

--- a/src/main/java/mate/academy/model/Book.java
+++ b/src/main/java/mate/academy/model/Book.java
@@ -14,7 +14,6 @@ import java.util.HashSet;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.SQLDelete;
@@ -30,13 +29,13 @@ public class Book {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @NonNull
+    @Column(nullable = false)
     private String title;
-    @NonNull
+    @Column(nullable = false)
     private String author;
-    @NonNull
+    @Column(nullable = false)
     private String isbn;
-    @NonNull
+    @Column(nullable = false)
     private BigDecimal price;
     private String description;
     private String coverImage;

--- a/src/main/java/mate/academy/model/Book.java
+++ b/src/main/java/mate/academy/model/Book.java
@@ -5,11 +5,18 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -35,4 +42,14 @@ public class Book {
     private String coverImage;
     @Column(nullable = false)
     private boolean isDeleted = false;
+    @ManyToMany
+    @JoinTable(
+            name = "books_categories",
+            joinColumns = @JoinColumn(name = "book_id"),
+            inverseJoinColumns = @JoinColumn(name = "category_id")
+    )
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private Set<Category> categories = new HashSet<>();
+
 }

--- a/src/main/java/mate/academy/model/Category.java
+++ b/src/main/java/mate/academy/model/Category.java
@@ -6,7 +6,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
@@ -22,7 +21,7 @@ public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @NotNull
+    @Column(nullable = false)
     private String name;
     private String description;
     @Column(nullable = false)

--- a/src/main/java/mate/academy/model/Category.java
+++ b/src/main/java/mate/academy/model/Category.java
@@ -1,0 +1,30 @@
+package mate.academy.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@Setter
+@SQLDelete(sql = "UPDATE categories SET is_deleted = true WHERE id=?")
+@SQLRestriction("is_deleted=false")
+@Table(name = "categories")
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotNull
+    private String name;
+    private String description;
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+}

--- a/src/main/java/mate/academy/model/Role.java
+++ b/src/main/java/mate/academy/model/Role.java
@@ -10,11 +10,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.security.core.GrantedAuthority;
 
 @Entity
 @Getter
 @Setter
+@SQLDelete(sql = "UPDATE roles SET is_deleted = true WHERE id=?")
+@SQLRestriction("is_deleted=false")
 @Table(name = "roles")
 public class Role implements GrantedAuthority {
     @Id
@@ -23,6 +27,8 @@ public class Role implements GrantedAuthority {
     @Column(nullable = false, unique = true)
     @Enumerated(EnumType.STRING)
     private RoleName role;
+    @Column(nullable = false)
+    private boolean isDeleted = false;
 
     @Override
     public String getAuthority() {

--- a/src/main/java/mate/academy/model/User.java
+++ b/src/main/java/mate/academy/model/User.java
@@ -2,7 +2,6 @@ package mate.academy.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;

--- a/src/main/java/mate/academy/model/User.java
+++ b/src/main/java/mate/academy/model/User.java
@@ -2,6 +2,7 @@ package mate.academy.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -14,8 +15,10 @@ import jakarta.validation.constraints.NotNull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.security.core.GrantedAuthority;
@@ -47,6 +50,8 @@ public class User implements UserDetails {
             joinColumns = @JoinColumn(name = "user_id"),
             inverseJoinColumns = @JoinColumn(name = "role_id")
     )
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Set<Role> roles = new HashSet<>();
     @Column(nullable = false)
     private boolean isDeleted = false;

--- a/src/main/java/mate/academy/model/User.java
+++ b/src/main/java/mate/academy/model/User.java
@@ -10,7 +10,6 @@ import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -36,11 +35,11 @@ public class User implements UserDetails {
     @Column(nullable = false, unique = true)
     @Email
     private String email;
-    @NotNull
+    @Column(nullable = false)
     private String password;
-    @NotNull
+    @Column(nullable = false)
     private String firstName;
-    @NotNull
+    @Column(nullable = false)
     private String lastName;
     private String shippingAddress;
     @ManyToMany

--- a/src/main/java/mate/academy/repository/book/BookRepository.java
+++ b/src/main/java/mate/academy/repository/book/BookRepository.java
@@ -1,9 +1,31 @@
 package mate.academy.repository.book;
 
+import java.util.List;
+import java.util.Optional;
+import mate.academy.dto.book.BookDto;
+import mate.academy.dto.book.CreateBookRequestDto;
 import mate.academy.model.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface BookRepository extends JpaRepository<Book, Long>, JpaSpecificationExecutor<Book> {
+    @EntityGraph(attributePaths = "categories")
+    BookDto save(CreateBookRequestDto createBookRequestDto);
+
+    @EntityGraph(attributePaths = "categories")
+    Page<Book> findAll(Pageable pageable);
+
+    @EntityGraph(attributePaths = "categories")
+    Page<Book> findAll(Specification<Book> bookSpecification, Pageable pageable);
+
+    @EntityGraph(attributePaths = "categories")
+    Optional<Book> findById(Long id);
+
     boolean existsByIsbn(String isbn);
+
+    List<Book> findAllByCategories_Id(Long categoryId, Pageable pageable);
 }

--- a/src/main/java/mate/academy/repository/category/CategoryRepository.java
+++ b/src/main/java/mate/academy/repository/category/CategoryRepository.java
@@ -1,0 +1,8 @@
+package mate.academy.repository.category;
+
+import mate.academy.model.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Category findByName(String name);
+}

--- a/src/main/java/mate/academy/security/JwtAuthenticationFilter.java
+++ b/src/main/java/mate/academy/security/JwtAuthenticationFilter.java
@@ -5,7 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -15,13 +15,23 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 @Component
-@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String TOKEN_HEADER = "Bearer ";
     private final JwtUtil jwtUtil;
     private final UserDetailsService userDetailsService;
+    private final HandlerExceptionResolver resolver;
+
+    public JwtAuthenticationFilter(
+            JwtUtil jwtUtil,
+            UserDetailsService userDetailsService,
+            @Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+        this.resolver = resolver;
+    }
 
     @Override
     protected void doFilterInternal(
@@ -30,13 +40,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
         String token = getToken(request);
-        if (token != null && jwtUtil.isValidToken(token)) {
-            String username = jwtUtil.getUsername(token);
-            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
-            Authentication authentication = new UsernamePasswordAuthenticationToken(
-                    userDetails, null, userDetails.getAuthorities()
-            );
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        try {
+            if (token != null && jwtUtil.isValidToken(token)) {
+                String username = jwtUtil.getUsername(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities()
+                );
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception e) {
+            resolver.resolveException(request, response, null, e);
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/mate/academy/service/BookService.java
+++ b/src/main/java/mate/academy/service/BookService.java
@@ -2,6 +2,7 @@ package mate.academy.service;
 
 import java.util.List;
 import mate.academy.dto.book.BookDto;
+import mate.academy.dto.book.BookDtoWithoutCategoryIds;
 import mate.academy.dto.book.BookSearchParameters;
 import mate.academy.dto.book.CreateBookRequestDto;
 import org.springframework.data.domain.Pageable;
@@ -18,4 +19,6 @@ public interface BookService {
     void deleteById(Long id);
 
     List<BookDto> search(BookSearchParameters searchParameters, Pageable pageable);
+
+    List<BookDtoWithoutCategoryIds> getBooksByCategoryId(Long id, Pageable pageable);
 }

--- a/src/main/java/mate/academy/service/CategoryService.java
+++ b/src/main/java/mate/academy/service/CategoryService.java
@@ -2,16 +2,17 @@ package mate.academy.service;
 
 import java.util.List;
 import mate.academy.dto.category.CategoryDto;
+import mate.academy.dto.category.CreateCategoryRequestDto;
 import org.springframework.data.domain.Pageable;
 
 public interface CategoryService {
-    CategoryDto save(CategoryDto requestDto);
+    CategoryDto save(CreateCategoryRequestDto requestDto);
 
     List<CategoryDto> findAll(Pageable pageable);
 
     CategoryDto getById(Long id);
 
-    CategoryDto update(Long id, CategoryDto categoryDto);
+    CategoryDto update(Long id, CreateCategoryRequestDto requestDto);
 
     void deleteById(Long id);
 }

--- a/src/main/java/mate/academy/service/CategoryService.java
+++ b/src/main/java/mate/academy/service/CategoryService.java
@@ -1,0 +1,17 @@
+package mate.academy.service;
+
+import java.util.List;
+import mate.academy.dto.category.CategoryDto;
+import org.springframework.data.domain.Pageable;
+
+public interface CategoryService {
+    CategoryDto save(CategoryDto requestDto);
+
+    List<CategoryDto> findAll(Pageable pageable);
+
+    CategoryDto getById(Long id);
+
+    CategoryDto update(Long id, CategoryDto categoryDto);
+
+    void deleteById(Long id);
+}

--- a/src/main/java/mate/academy/service/impl/BookServiceImpl.java
+++ b/src/main/java/mate/academy/service/impl/BookServiceImpl.java
@@ -100,8 +100,8 @@ public class BookServiceImpl implements BookService {
         );
     }
 
-    private Set<Category> getCategoriesByIds(List<Long> ids) {
-        return ids.stream()
+    private Set<Category> getCategoriesByIds(List<Long> categoryIds) {
+        return categoryIds.stream()
                 .map(categoryService::getById)
                 .map(categoryMapper::toEntity)
                 .collect(Collectors.toSet());

--- a/src/main/java/mate/academy/service/impl/BookServiceImpl.java
+++ b/src/main/java/mate/academy/service/impl/BookServiceImpl.java
@@ -1,17 +1,23 @@
 package mate.academy.service.impl;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import mate.academy.dto.book.BookDto;
+import mate.academy.dto.book.BookDtoWithoutCategoryIds;
 import mate.academy.dto.book.BookSearchParameters;
 import mate.academy.dto.book.CreateBookRequestDto;
 import mate.academy.exception.DuplicateResourceException;
 import mate.academy.exception.EntityNotFoundException;
 import mate.academy.mapper.BookMapper;
+import mate.academy.mapper.CategoryMapper;
 import mate.academy.model.Book;
+import mate.academy.model.Category;
 import mate.academy.repository.book.BookRepository;
 import mate.academy.repository.book.BookSpecificationBuilder;
 import mate.academy.service.BookService;
+import mate.academy.service.CategoryService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
@@ -22,15 +28,18 @@ public class BookServiceImpl implements BookService {
     private final BookRepository bookRepository;
     private final BookMapper bookMapper;
     private final BookSpecificationBuilder bookSpecificationBuilder;
+    private final CategoryService categoryService;
+    private final CategoryMapper categoryMapper;
 
     @Override
     public BookDto save(CreateBookRequestDto requestDto) {
-        Book book = bookMapper.toModel(requestDto);
+        Book book = bookMapper.toEntity(requestDto);
         if (bookRepository.existsByIsbn(book.getIsbn())) {
             throw new DuplicateResourceException("Book with ISBN "
                     + book.getIsbn()
                     + " already exists");
         }
+        book.setCategories(getCategoriesByIds(requestDto.categoryIds()));
         bookRepository.save(book);
         return bookMapper.toDto(book);
     }
@@ -56,6 +65,7 @@ public class BookServiceImpl implements BookService {
             throw new DuplicateResourceException("Book with ISBN " + requestDto.isbn()
                     + " already exists");
         }
+        book.setCategories(getCategoriesByIds(requestDto.categoryIds()));
         bookMapper.updateBookFromDto(requestDto, book);
         return bookMapper.toDto(bookRepository.save(book));
     }
@@ -74,9 +84,26 @@ public class BookServiceImpl implements BookService {
                 .toList();
     }
 
+    @Override
+    public List<BookDtoWithoutCategoryIds> getBooksByCategoryId(Long id, Pageable pageable) {
+        if (categoryService.getById(id) == null) {
+            throw new EntityNotFoundException("Can't find category by id: " + id);
+        }
+        return bookRepository.findAllByCategories_Id(id, pageable).stream()
+                .map(bookMapper::toDtoWithoutCategories)
+                .toList();
+    }
+
     private Book getBookById(Long id) {
         return bookRepository.findById(id).orElseThrow(() ->
                 new EntityNotFoundException("Can't find book by id: " + id)
         );
+    }
+
+    private Set<Category> getCategoriesByIds(List<Long> ids) {
+        return ids.stream()
+                .map(categoryService::getById)
+                .map(categoryMapper::toEntity)
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/mate/academy/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/mate/academy/service/impl/CategoryServiceImpl.java
@@ -3,6 +3,7 @@ package mate.academy.service.impl;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import mate.academy.dto.category.CategoryDto;
+import mate.academy.dto.category.CreateCategoryRequestDto;
 import mate.academy.exception.DuplicateResourceException;
 import mate.academy.exception.EntityNotFoundException;
 import mate.academy.mapper.CategoryMapper;
@@ -19,7 +20,7 @@ public class CategoryServiceImpl implements CategoryService {
     private final CategoryMapper categoryMapper;
 
     @Override
-    public CategoryDto save(CategoryDto requestDto) {
+    public CategoryDto save(CreateCategoryRequestDto requestDto) {
         Category category = categoryMapper.toEntity(requestDto);
         if (categoryRepository.findByName(category.getName()) != null) {
             throw new DuplicateResourceException("Category with name:"
@@ -44,14 +45,14 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     @Override
-    public CategoryDto update(Long id, CategoryDto categoryDto) {
+    public CategoryDto update(Long id, CreateCategoryRequestDto requestDto) {
         Category category = getCategoryById(id);
         if (!categoryRepository.findByName(category.getName()).getId().equals(id)) {
             throw new DuplicateResourceException("Category with name:"
                     + category.getName()
                     + " already exists");
         }
-        categoryMapper.updateCategoryFromDto(categoryDto, category);
+        categoryMapper.updateCategoryFromDto(requestDto, category);
         return categoryMapper.toDto(categoryRepository.save(category));
     }
 

--- a/src/main/java/mate/academy/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/mate/academy/service/impl/CategoryServiceImpl.java
@@ -1,0 +1,68 @@
+package mate.academy.service.impl;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import mate.academy.dto.category.CategoryDto;
+import mate.academy.exception.DuplicateResourceException;
+import mate.academy.exception.EntityNotFoundException;
+import mate.academy.mapper.CategoryMapper;
+import mate.academy.model.Category;
+import mate.academy.repository.category.CategoryRepository;
+import mate.academy.service.CategoryService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+    private final CategoryRepository categoryRepository;
+    private final CategoryMapper categoryMapper;
+
+    @Override
+    public CategoryDto save(CategoryDto requestDto) {
+        Category category = categoryMapper.toEntity(requestDto);
+        if (categoryRepository.findByName(category.getName()) != null) {
+            throw new DuplicateResourceException("Category with name:"
+                    + category.getName()
+                    + " already exists");
+        }
+        categoryRepository.save(category);
+        return categoryMapper.toDto(category);
+    }
+
+    @Override
+    public List<CategoryDto> findAll(Pageable pageable) {
+        return categoryRepository.findAll(pageable).stream()
+                .map(categoryMapper::toDto)
+                .toList();
+    }
+
+    @Override
+    public CategoryDto getById(Long id) {
+        Category category = getCategoryById(id);
+        return categoryMapper.toDto(category);
+    }
+
+    @Override
+    public CategoryDto update(Long id, CategoryDto categoryDto) {
+        Category category = getCategoryById(id);
+        if (!categoryRepository.findByName(category.getName()).getId().equals(id)) {
+            throw new DuplicateResourceException("Category with name:"
+                    + category.getName()
+                    + " already exists");
+        }
+        categoryMapper.updateCategoryFromDto(categoryDto, category);
+        return categoryMapper.toDto(categoryRepository.save(category));
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        categoryRepository.deleteById(id);
+    }
+
+    private Category getCategoryById(Long id) {
+        return categoryRepository.findById(id).orElseThrow(() ->
+                new EntityNotFoundException("Can't find category by id: " + id)
+        );
+    }
+}

--- a/src/main/resources/db/changelog/changes/05-create-roles-table.yaml
+++ b/src/main/resources/db/changelog/changes/05-create-roles-table.yaml
@@ -19,3 +19,9 @@ databaseChangeLog:
                   constraints:
                     nullable: false
                     unique: true
+              - column:
+                  name: is_deleted
+                  type: bit
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false

--- a/src/main/resources/db/changelog/changes/06-insert-roles.yaml
+++ b/src/main/resources/db/changelog/changes/06-insert-roles.yaml
@@ -1,7 +1,7 @@
 databaseChangeLog:
   - changeSet:
       id: insert-roles
-      author: your_name
+      author: Vitalii Pavlyk
       changes:
         - insert:
             tableName: roles

--- a/src/main/resources/db/changelog/changes/10-create-categories-table.yaml
+++ b/src/main/resources/db/changelog/changes/10-create-categories-table.yaml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-categories-table
+      author: Vitalii Pavlyk
+      changes:
+        - createTable:
+            tableName: categories
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: varchar(255)
+              - column:
+                  name: is_deleted
+                  type: bit
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false

--- a/src/main/resources/db/changelog/changes/11-insert-categories.yaml
+++ b/src/main/resources/db/changelog/changes/11-insert-categories.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: insert-categories
+      author: Vitalii Pavlyk
+      changes:
+        - insert:
+            tableName: categories
+            columns:
+              - column: {name: name, value: "Non-fiction"}
+              - column: {name: description, value: "Documentary books"}
+        - insert:
+            tableName: categories
+            columns:
+              - column: { name: name, value: "Prose" }
+              - column: { name: description, value: "Genre with no formal metrical structure" }

--- a/src/main/resources/db/changelog/changes/12-create-books_categories-table.yaml
+++ b/src/main/resources/db/changelog/changes/12-create-books_categories-table.yaml
@@ -1,0 +1,35 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-books_categories-table
+      author: Vitalii Pavlyk
+      changes:
+        - createTable:
+            tableName: books_categories
+            columns:
+              - column:
+                  name: book_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: category_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: books_categories
+            columnNames: book_id, category_id
+        - addForeignKeyConstraint:
+            baseTableName: books_categories
+            baseColumnNames: book_id
+            constraintName: fk_books_categories_book
+            referencedTableName: books
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: books_categories
+            baseColumnNames: category_id
+            constraintName: fk_books_categories_category
+            referencedTableName: categories
+            referencedColumnNames: id
+            onDelete: CASCADE

--- a/src/main/resources/db/changelog/changes/13-update-books-categories.yaml
+++ b/src/main/resources/db/changelog/changes/13-update-books-categories.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - changeSet:
+      id: assign-book-to-first-category
+      author: Vitalii Pavlyk
+      changes:
+        - insert:
+            tableName: books_categories
+            columns:
+              - column:
+                  name: book_id
+                  value: 1
+              - column:
+                  name: category_id
+                  value: 1
+  - changeSet:
+      id: assign-book-to-second-category
+      author: Vitalii Pavlyk
+      changes:
+        - insert:
+            tableName: books_categories
+            columns:
+              - column:
+                  name: book_id
+                  value: 2
+              - column:
+                  name: category_id
+                  value: 2

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -17,3 +17,11 @@ databaseChangeLog:
       file: db/changelog/changes/08-update-users-roles.yaml
   - include:
       file: db/changelog/changes/09-add-column-is_deleted-users.yaml
+  - include:
+      file: db/changelog/changes/10-create-categories-table.yaml
+  - include:
+      file: db/changelog/changes/11-insert-categories.yaml
+  - include:
+      file: db/changelog/changes/12-create-books_categories-table.yaml
+  - include:
+      file: db/changelog/changes/13-update-books-categories.yaml


### PR DESCRIPTION
Category entity
Category: Represents a category that a book can belong to.

Add a new entity Category with the next fields:
id (Long, PK)
name (String, not null)
description (String)
Book class now should have the following field: private Set<Category> categories = new HashSet<>();
HINT: you can use the next method in the BookRepository.class:

   List<Book> findAllByCategoryId(Long categoryId);

Implement the CategoryRepository interface that will use JpaRepository interface
Implement DTO classes for Category entity
Modify the BookMapper class to have such methods:
BookDto toDto(Book book);
Book toEntity(CreateBookRequestDto bookDto);
BookDtoWithoutCategoryIds toDtoWithoutCategories(Book book); (HINT: BookDtoWithoutCategoryIds class could be used as a response class for @GetMapping("/{id}/books") endpoint). Why may we need this class? On the UI we may have pages where we don't need to receive information as to which categories the book relates to. This is a common approach to have several response DTOs for a single model.
@AfterMapping default void setCategoryIds(@MappingTarget BookDto bookDto, Book book)
Add CategoryMapper class with such methods:
CategoryDto toDto(Category category);
Category toEntity(CategoryDto categoryDTO);
Implement CategoryService interface with methods and CategoryServiceImpl class:
List findAll();
CategoryDto getById(Long id);
CategoryDto save(CategoryDto categoryDto);
CategoryDto update(Long id, CategoryDto categoryDto);
void deleteById(Long id);
Add CategoryController class with such methods:
public CategoryDto createCategory(CategoryDto categoryDto)
public List getAll()
public CategoryDto getCategoryById(Long id)
public CategoryDto updateCategory(Long id, CategoryDto categoryDto)
public void deleteCategory(Long id)
public List getBooksByCategoryId(Long id) (endpoint: "/{id}/books")